### PR TITLE
Support for KV Storage

### DIFF
--- a/packages/vite-plugin-cloudflare/src/cli.ts
+++ b/packages/vite-plugin-cloudflare/src/cli.ts
@@ -43,6 +43,8 @@ cli
   .option("-p, --port <input>", "miniflare port", { default: 3000 })
   .option("-d, --debug", "enable debugging", { default: false })
   .option("-m, --minify", "enable minification", { default: false })
+  .option("-k, --kv <namespace>", "KV namespace to bind")
+  .option("--kv-persist [path]", "persist KV data (to optional path)")
   .option("--sourcemap", "enable sourcemaps", { default: false })
   .option("--wrangler-config", "load wrangler config automatically", { default: true })
   .option("--env", "load env automatically", { default: true })
@@ -68,6 +70,10 @@ cli
       wranglerConfigPath: options.wranglerConfigPath,
       packagePath: options.packagePath,
       envPath: options.envPath,
+      ...(options.kv ? {
+        kvNamespaces: Array.isArray(options.kv) ? options.kv : [options.kv],
+        kvPersist: options.kvPersist
+      } : {})
       // log: options.debug ? new ConsoleLog(true) : false,
     });
 

--- a/packages/vite-plugin-cloudflare/src/types.ts
+++ b/packages/vite-plugin-cloudflare/src/types.ts
@@ -5,6 +5,8 @@ export interface Options {
   wranglerConfigPath: boolean;
   packagePath: boolean;
   envPath: boolean;
+  kv?: string[];
+  kvPersist?: boolean;
 }
 
 export interface DevOptions extends Options {


### PR DESCRIPTION
See more at https://miniflare.dev/storage/kv 

Added arguments
```
--k, --kv <namespace>      KV namespace to bind
     --kv-persist [path]   Persist KV data (to optional path)
```

Add bindings to KV in typescript
```ts
declare global {
  var MyKVNamespace: KVNamespace;
}
```

Remeber to reference the bindings correctly in wrangler.toml according to [developers.cloudflare.com/workers](https://developers.cloudflare.com/workers/runtime-apis/kv/?_gl=1*1khfq29*_ga*MTAxMzcxOTIwNy4xNjQ5MTQyMTM0*_gid*Njk4NTE2MTAuMTY0OTE0MjEzNA..#kv-bindings)