### PR TITLE
Support request bodies

### DIFF
--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -9,7 +9,7 @@ export function toRequest(req: Connect.IncomingMessage): Request {
     headers: req.headers as Record<string, string>,
     method: req.method,
     body: req.method === "GET" || req.method === "HEAD" ? undefined : req as any,
-    duplex: "half"
+    duplex: "half" as any
   });
 }
 

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -9,7 +9,8 @@ export function toRequest(req: Connect.IncomingMessage): Request {
     headers: req.headers as Record<string, string>,
     method: req.method,
     body: req.method === "GET" || req.method === "HEAD" ? undefined : req as any,
-    duplex: "half" as any
+    // @ts-ignore
+    duplex: "half" 
   });
 }
 

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -8,6 +8,8 @@ export function toRequest(req: Connect.IncomingMessage): Request {
   return new Request(url.href, {
     headers: req.headers as Record<string, string>,
     method: req.method,
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : req,
+    duplex: "half"
   });
 }
 

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -8,7 +8,7 @@ export function toRequest(req: Connect.IncomingMessage): Request {
   return new Request(url.href, {
     headers: req.headers as Record<string, string>,
     method: req.method,
-    body: req.method === "GET" || req.method === "HEAD" ? undefined : req,
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : req as any,
     duplex: "half"
   });
 }


### PR DESCRIPTION
Fixes #20 

Inspired by [HatTip's code](https://github.com/hattipjs/hattip/blob/main/packages/adapter/adapter-node/src/common.ts#L124).

I had to add the duplex bit to circumvent an `RequestInit: duplex option is required when sending a body.` error