### PR TITLE
Allow specifying other worker files for hot reload

### DIFF
--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -37,6 +37,8 @@ type Options = {
   miniflare?: Omit<MiniflareOptions, "script" | "watch">;
   // the worker file (required)
   scriptPath: string;
+  // a fast-glob pattern for files who's changes should reload the server (optional)
+  workerFilesPattern?: string;
 };
 ```
 

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "buffer-es6": "^4.9.3",
     "cac": "^6.7.12",
+    "fast-glob": "^3.2.11",
     "mlly": "^0.3.16",
     "modern-node-polyfills": "^0.0.9",
     "node-fetch": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,7 @@ importers:
       buffer-es6: ^4.9.3
       cac: ^6.7.12
       esbuild: ^0.17.5
+      fast-glob: ^3.2.11
       miniflare: ^2.6.0
       mlly: ^0.3.16
       modern-node-polyfills: ^0.0.9
@@ -127,6 +128,7 @@ importers:
     dependencies:
       buffer-es6: 4.9.3
       cac: 6.7.12
+      fast-glob: 3.2.11
       mlly: 0.3.16
       modern-node-polyfills: 0.0.9
       node-fetch: 2.6.7


### PR DESCRIPTION
The `isImportedByWorkerFile` heuristics is clever but doesn't go quite far enough in my opinion; this adds the option of specifying a glob pattern for files which should be considered part of the worker, and for which we should perform HMR on the worker when they are changed.

Been using something like this in my project and figured I'd contribute upstream but no worries if this isn't a desired API